### PR TITLE
Add documentation to XBI Format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: test project
+
+on:
+  pull_request:
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - .github/workflows/lint.yml
+  push:
+    branches:
+      - main
+      - development
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.*'
+      - .github/workflows/lint.yml
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    runs-on: self-hosted
+    steps:
+      - name: ☁️Checkout git repo
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          token: ${{ secrets.GH_PAT }}
+      - name: ⚙️Get nightly rust toolchain with wasm target
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2021-11-01
+          profile: minimal
+          components: clippy
+          override: true
+      - name: 📑 Lint code
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,19 @@
+[formatting]
+align_comments = false
+# Align consecutive entries vertically.
+align_entries = true
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 170
+# Omit white space padding from single-line arrays
+compact_arrays = false
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = true
+
+exclude = [ "evm/sputnik-evm/Cargo.toml", "vendor/frontier/Cargo.toml" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,2 @@
 [workspace]
-members = [
-    'sabi',
-    'scabi',
-    'xbi-format'
-]
+members = [ 'sabi', 'scabi', 'xbi-format' ]

--- a/README.md
+++ b/README.md
@@ -1,100 +1,19 @@
-### XBI Standard - interteam coworking dashboard
+# XBI
 
-First implementation blueprint in `src/xbi_format.rs`
+An XCM-based high-level standard and interface (ABI) for smart contracts.
 
-### Basic Types 
-```rust
-/// Global XBI Types.
-/// Could also introduce t3rn-primitives/abi but perhaps easier to rely on sp_std / global types
-pub type Data = Vec<u8>;
-pub type AssetId = u32; // Could also be xcm::MultiAsset
-pub type Value = u128; // Could also be [u64; 2] or sp_core::U128
-pub type ValueEvm = sp_core::U256; // Could also be [u64; 4]
-pub type Gas = u64; // [u64; 4]
-pub type AccountId32 = sp_runtime::AccountId32;
-pub type AccountId20 = sp_core::H160; // Could also take it from MultiLocation::Junction::AccountKey20 { network: NetworkId, key: [u8; 20] },
+## W3F grants
 
-```
+At t3rn, we aim for XBI to become the de-facto standord for integrating with smart contracts all cross the ecosystem. 
+To facilitate that, we aim to implement XBI as a set of grants to enable a transparent, usable specification. 
 
-## XBI Format specification
-```rust
-pub enum XBIInstr {
-  CallNative {
-    payload: Data,
-  },
-  CallEvm {
-    source: AccountId20, // Could use either [u8; 20] or Junction::AccountKey20
-    dest: AccountId20,   // Could use either [u8; 20] or Junction::AccountKey20
-    value: Value,
-    input: Data,
-    gas_limit: Gas,
-    max_fee_per_gas: ValueEvm,
-    max_priority_fee_per_gas: Option<ValueEvm>,
-    nonce: Option<ValueEvm>,
-    access_list: Vec<(AccountId20, Vec<sp_core::H256>)>, // Could use Vec<([u8; 20], Vec<[u8; 32]>)>,
-  },
-  CallWasm {
-    dest: AccountId32,
-    value: Value,
-    gas_limit: Gas,
-    storage_deposit_limit: Option<Value>,
-    data: Data,
-  },
-  CallCustom {
-    caller: AccountId32,
-    dest: AccountId32,
-    value: Value,
-    input: Data,
-    additional_params: Option<Vec<Data>>,
-  },
-  Transfer {
-    dest: AccountId32,
-    value: Value,
-  },
-  TransferORML {
-    currency_id: AssetId,
-    dest: AccountId32,
-    value: Value,
-  },
-  TransferAssets {
-    currency_id: AssetId,
-    dest: AccountId32,
-    value: Value,
-  },
-  Result {
-    outcome: XBICheckOutStatus,
-    output: Data,
-    witness: Data,
-  },
-  Notification {
-    kind: XBINotificationKind,
-    instruction_id: Data,
-    extra: Data,
-  },
-}
-```
+## Standards
 
-## XBI Metadata specification
-- `metadata`: `Lifecycle status notifications`
-    - `Sent (action timeout, notification timeout)`
-    - `Delivered (action timeout, notification timeout)`
-    - `Executed (action timeout, notification timeout)`
-    - `Destination / Bridge security guarantees (e.g. in confirmation no for PoW, finality proofs)`
-    - `max_exec_cost`: `Balance` : `Maximal cost / fees for execution of delivery`
-    - `max_notification_cost`: `Balance` : `Maximal cost / fees per delivering notification`
+The XBI standard is undergoing a lot of iteration, the details can be found in ./docs.
 
+- The opening proposal is [here](./docs/xbi-w3f-grant.md), with the PSP for such [here](./docs/PSP-33-XBI-Standard.md)
 
-Or directly from `src/xbi_format.rs`
-```rust
-#[derive(Clone, Eq, PartialEq, Debug, Default, Encode, Decode, TypeInfo)]
-pub struct XBIMetadata {
-  pub id: sp_core::H256,
-  pub dest_para_id: u32,
-  pub src_para_id: u32,
-  pub sent: ActionNotificationTimeouts,
-  pub delivered: ActionNotificationTimeouts,
-  pub executed: ActionNotificationTimeouts,
-  pub max_exec_cost: Value,
-  pub max_notifications_cost: Value,
-}
-```
+### XBI Extensions
+
+Whilst XBI should be modular, so should extensions on XBI. Each extension can be roughly explained here, and any links to the 
+grant proposals seen below:

--- a/sabi/Cargo.toml
+++ b/sabi/Cargo.toml
@@ -1,20 +1,24 @@
 [package]
-name = "substrate-abi"
-version = "0.1.0"
-edition = "2021"
+authors     = [ "t3rn ltd. <team@t3rn.io>" ]
+description = "XBI Substrate ABI"
+edition     = "2021"
+homepage    = "https://t3rn.io"
+license     = "Apache-2.0"
+name        = "substrate-abi"
+repository  = "https://github.com/t3rn/xbi/"
+version     = "0.1.0"
 
 [dependencies]
+log   = { version = "0.4.14", default-features = false }
 serde = { default-features = false, version = "1.0", optional = true }
-log = { version = "0.4.14", default-features = false }
 
-codec = { package = "parity-scale-codec", version = "3", default-features = false }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+codec      = { package = "parity-scale-codec", version = "3", default-features = false }
+scale-info = { version = "2.1.1", default-features = false, features = [ "derive" ] }
 
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core    = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-
+sp-std     = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 [features]
-default = ["std"]
-std = ["sp-std/std", "sp-core/std", "sp-runtime/std", "scale-info/std", "serde/std", "codec/std", "log/std"]
+default = [ "std" ]
+std     = [ "sp-std/std", "sp-core/std", "sp-runtime/std", "scale-info/std", "serde/std", "codec/std", "log/std" ]

--- a/sabi/src/error.rs
+++ b/sabi/src/error.rs
@@ -15,12 +15,14 @@ pub enum Error {
     FailedToAssociateTypes,
 }
 
+#[allow(clippy::from_over_into)]
 impl<const IDX: u8> Into<DispatchError> for ModuleErrorProvider<IDX> {
     fn into(self) -> DispatchError {
         DispatchError::Module(self.into())
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<[u8; 4]> for Error {
     fn into(self) -> [u8; 4] {
         match self {
@@ -31,6 +33,7 @@ impl Into<[u8; 4]> for Error {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<&'static str> for Error {
     fn into(self) -> &'static str {
         match self {
@@ -41,6 +44,7 @@ impl Into<&'static str> for Error {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl<const IDX: u8> Into<ModuleError> for ModuleErrorProvider<IDX> {
     fn into(self) -> ModuleError {
         let error: [u8; 4] = self.0.clone().into();

--- a/sabi/src/lib.rs
+++ b/sabi/src/lib.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 /// Global XBI Types.
 pub type Data = Vec<u8>;
 /// A representation of an Asset Id, this is utilised for xbi instructions relating to multiple assets
-pub type AssetId = u64; // Could also be xcm::MultiAsset
+pub type AssetId = u32; // Could also be xcm::MultiAsset
 pub type Gas = u64;
 pub type AccountId32 = sp_runtime::AccountId32;
 pub type AccountId20 = sp_core::H160; // Could also take it from MultiLocation::Junction::AccountKey20 { network: NetworkId, key: [u8; 20] },

--- a/sabi/src/lib.rs
+++ b/sabi/src/lib.rs
@@ -70,7 +70,7 @@ impl TryConvert<(AccountId20, [u8; 12])> for SubstrateAbiConverter {
         dest_bytes.append(&mut value.0.encode());
         dest_bytes.append(&mut value.1.encode());
 
-        Decode::decode(&mut &dest_bytes.as_slice()[..])
+        Decode::decode(&mut dest_bytes.as_slice())
             .map_err(|_e| Error::FailedToCastBetweenTypesValue)
     }
 }
@@ -85,7 +85,7 @@ impl TryConvert<AccountId32> for SubstrateAbiConverter {
 
         dest_bytes.append(&mut account_32_encoded[..20].to_vec());
 
-        Decode::decode(&mut &dest_bytes.as_slice()[..])
+        Decode::decode(&mut dest_bytes.as_slice())
             .map_err(|_e| Error::FailedToCastBetweenTypesValue)
     }
 }

--- a/sabi/src/lib.rs
+++ b/sabi/src/lib.rs
@@ -2,8 +2,8 @@ use codec::{Decode, Encode};
 use error::Error;
 use sp_core::U256;
 use sp_runtime::traits::Convert;
+use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
-use std::marker::PhantomData;
 
 /// Global XBI Types.
 pub type Data = Vec<u8>;

--- a/scabi/Cargo.toml
+++ b/scabi/Cargo.toml
@@ -1,21 +1,26 @@
 [package]
-name = "substrate-contracts-abi"
-version = "0.1.0"
-edition = "2021"
+authors     = [ "t3rn ltd. <team@t3rn.io>" ]
+description = "XBI Substrate contracts ABI"
+edition     = "2021"
+homepage    = "https://t3rn.io"
+license     = "Apache-2.0"
+name        = "substrate-contracts-abi"
+repository  = "https://github.com/t3rn/xbi/"
+version     = "0.1.0"
 
 [dependencies]
+log   = { version = "0.4.14", default-features = false }
 serde = { default-features = false, version = "1.0", optional = true }
-log = { version = "0.4.14", default-features = false }
 
-codec = { package = "parity-scale-codec", version = "3", default-features = false }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+codec      = { package = "parity-scale-codec", version = "3", default-features = false }
+scale-info = { version = "2.1.1", default-features = false, features = [ "derive" ] }
 
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core    = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std     = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 substrate-abi = { path = "../sabi", default-features = false }
 
 [features]
-default = ["std"]
-std = ["sp-std/std", "sp-core/std", "sp-runtime/std", "substrate-abi/std", "scale-info/std", "serde/std", "codec/std", "log/std"]
+default = [ "std" ]
+std     = [ "sp-std/std", "sp-core/std", "sp-runtime/std", "substrate-abi/std", "scale-info/std", "serde/std", "codec/std", "log/std" ]

--- a/scabi/src/error.rs
+++ b/scabi/src/error.rs
@@ -20,12 +20,14 @@ impl From<substrate_abi::error::Error> for Error {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl<const IDX: u8> Into<DispatchError> for ModuleErrorProvider<IDX> {
     fn into(self) -> DispatchError {
         DispatchError::Module(self.into())
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl<const IDX: u8> Into<[u8; 4]> for ModuleErrorProvider<IDX> {
     fn into(self) -> [u8; 4] {
         match self.0 {
@@ -37,6 +39,7 @@ impl<const IDX: u8> Into<[u8; 4]> for ModuleErrorProvider<IDX> {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<&'static str> for Error {
     fn into(self) -> &'static str {
         match self {
@@ -55,6 +58,7 @@ impl Into<&'static str> for Error {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl<const IDX: u8> Into<ModuleError> for ModuleErrorProvider<IDX> {
     fn into(self) -> ModuleError {
         let error: [u8; 4] = self.clone().into();

--- a/scabi/src/evm.rs
+++ b/scabi/src/evm.rs
@@ -107,8 +107,7 @@ mod tests {
             access_list,
         );
 
-        let call_wasm = SubstrateContractAbiConverter::try_convert(call_evm)
-            .unwrap();
+        let call_wasm = SubstrateContractAbiConverter::try_convert(call_evm).unwrap();
 
         assert_eq!(
             call_wasm,

--- a/scabi/src/evm.rs
+++ b/scabi/src/evm.rs
@@ -108,7 +108,6 @@ mod tests {
         );
 
         let call_wasm = SubstrateContractAbiConverter::try_convert(call_evm)
-            .unwrap()
             .unwrap();
 
         assert_eq!(

--- a/scabi/src/evm.rs
+++ b/scabi/src/evm.rs
@@ -22,6 +22,7 @@ pub struct CallEvm {
 }
 
 impl CallEvm {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         source: AccountId20,
         target: AccountId20,

--- a/scabi/src/wasm.rs
+++ b/scabi/src/wasm.rs
@@ -56,8 +56,8 @@ impl TryFrom<CallEvm> for CallWasm {
         let storage_deposit_limit = None;
         let data = call.input;
         Ok(CallWasm {
-            origin_source: origin_source,
-            dest: dest,
+            origin_source,
+            dest,
             value,
             gas_limit,
             storage_deposit_limit,

--- a/xbi-format/Cargo.toml
+++ b/xbi-format/Cargo.toml
@@ -1,25 +1,29 @@
 [package]
-name = "xbi-format"
-version = "0.1.0"
-edition = "2021"
+authors     = [ "t3rn ltd. <team@t3rn.io>" ]
+description = "XBI format for creating and handling XBI messages"
+edition     = "2021"
+homepage    = "https://t3rn.io"
+license     = "Apache-2.0"
+name        = "xbi-format"
+repository  = "https://github.com/t3rn/xbi/"
+version     = "0.1.0"
 
 [dependencies]
+log   = { version = "0.4.14", default-features = false }
 serde = { default-features = false, version = "1.0", optional = true }
-log = { version = "0.4.14", default-features = false }
 
-codec = { package = "parity-scale-codec", version = "3", default-features = false }
-scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+codec      = { package = "parity-scale-codec", version = "3", default-features = false }
+scale-info = { version = "2.1.1", default-features = false, features = [ "derive" ] }
 
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system  = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core       = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime    = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std        = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
-sabi = { path = "../sabi", default-features = false, package = "substrate-abi" }
+sabi  = { path = "../sabi", default-features = false, package = "substrate-abi" }
 scabi = { path = "../scabi", default-features = false, package = "substrate-contracts-abi" }
 
 [features]
-default = ["std"]
-std = ["sp-std/std", "sp-core/std", "sp-runtime/std", "frame-system/std", "frame-support/std", "sabi/std", "scabi/std"]
-
+default = [ "std" ]
+std     = [ "sp-std/std", "sp-core/std", "sp-runtime/std", "frame-system/std", "frame-support/std", "sabi/std", "scabi/std" ]

--- a/xbi-format/src/lib.rs
+++ b/xbi-format/src/lib.rs
@@ -42,6 +42,7 @@ impl Default for XBICheckOutStatus {
 // TODO: enrich the dtos in this library with reusable structs, so that the data is not flat.
 // e.g parachain dest & source are the same, but described by the variable over some dto.
 
+/// A representation of the state of an XBI message, meters relating to cost and any timeouts
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
 pub struct XBICheckOut {
     /// The requested instruction
@@ -134,14 +135,9 @@ pub struct XBIFormat {
 #[derive(Clone, Eq, PartialEq, Debug, TypeInfo)]
 pub enum XBIInstr {
     /// An opaque message providing the instruction identifier and some bytes
-    Unknown {
-        identifier: u8,
-        params: Vec<u8>,
-    },
+    Unknown { identifier: u8, params: Vec<u8> },
     /// A call native to the parachain, this is also opaque and can be custom
-    CallNative {
-        payload: Data,
-    },
+    CallNative { payload: Data },
     /// A call to an EVM contract
     CallEvm {
         source: AccountId20, // Could use either [u8; 20] or Junction::AccountKey20
@@ -172,10 +168,7 @@ pub enum XBIInstr {
         additional_params: Data,
     },
     /// A simple transfer
-    Transfer {
-        dest: AccountId32,
-        value: Value,
-    },
+    Transfer { dest: AccountId32, value: Value },
     /// A multiple asset transfer
     TransferAssets {
         currency_id: AssetId,

--- a/xbi-format/src/lib.rs
+++ b/xbi-format/src/lib.rs
@@ -294,6 +294,7 @@ impl XBIMetadata {
         <Hashing as Hasher>::hash(&self.id.encode()[..])
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: sp_core::H256,
         dest_para_id: u32,

--- a/xbi-format/src/lib.rs
+++ b/xbi-format/src/lib.rs
@@ -12,22 +12,24 @@ pub mod xbi_codec;
 use sabi::*;
 pub use xbi_codec::*;
 
+/// A representation of the status of an XBI execution
 #[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub enum XBICheckOutStatus {
-    // Success scenario
+    /// The XBI message was successful
     SuccessfullyExecuted,
-
-    // Failed execution scenarios
+    /// Failed to execute an XBI instruction
     ErrorFailedExecution,
+    /// An error occurred whilst sending the XCM message
     ErrorFailedOnXCMDispatch,
-
-    // Failed with exceeded costs scenarios
+    /// The execution exceeded the maximum cost provided in the message
     ErrorExecutionCostsExceededAllowedMax,
+    /// The notification cost for the message was exceeded
     ErrorNotificationsCostsExceededAllowedMax,
-
-    // Failed with exceeded timeout scenarios
+    /// The XBI reqeuest timed out when trying to dispatch the message
     ErrorSentTimeoutExceeded,
+    /// The XBI request timed out before the message was received by the target
     ErrorDeliveryTimeoutExceeded,
+    /// The message timed out before the execution occured on the target
     ErrorExecutionTimeoutExceeded,
 }
 
@@ -37,13 +39,22 @@ impl Default for XBICheckOutStatus {
     }
 }
 
+// TODO: enrich the dtos in this library with reusable structs, so that the data is not flat.
+// e.g parachain dest & source are the same, but described by the variable over some dto.
+
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
 pub struct XBICheckOut {
+    /// The requested instruction
     pub xbi: XBIInstr, // TODO: XBIInstr::Result(XbiResult { }), then the result can be a struct here
+    /// The status of the message
     pub resolution_status: XBICheckOutStatus,
     pub checkout_timeout: Timeout,
+    /// The metered cost of the message to be handled
     pub actual_execution_cost: Value,
+    /// The cost to send the message
     pub actual_delivery_cost: Value,
+    // TODO: this can be calculated by a function on XBICheckout
+    /// The cost of the message with the execution cost
     pub actual_aggregated_cost: Value,
 }
 
@@ -63,7 +74,9 @@ impl XBICheckOut {
                 witness: vec![],
             },
             resolution_status,
-            checkout_timeout: Default::default(), // FixMe: make below work - casting block no to timeout
+            checkout_timeout: Default::default(),
+            // fixme: make below work - casting block no to timeout
+            // provide some differential function so not to couple to `frame`
             // checkout_timeout: ((frame_system::Pallet::<T>::block_number() - delivery_timeout)
             //     * T::BlockNumber::from(T::ExpectedBlockTimeMs::get())).into(),
             actual_execution_cost,
@@ -72,6 +85,7 @@ impl XBICheckOut {
         }
     }
 
+    /// Instantiate a new checkout with default costs
     pub fn new_ignore_costs<T: frame_system::Config>(
         _delivery_timeout: T::BlockNumber,
         output: Vec<u8>,
@@ -84,8 +98,9 @@ impl XBICheckOut {
                 witness: vec![],
             },
             resolution_status,
-            checkout_timeout: Default::default(), // FixMe: make below work - casting block no to timeout
-            // checkout_timeout: ((frame_system::Pallet::<T>::block_number() - delivery_timeout)
+            checkout_timeout: Default::default(),
+            // fixme: make below work - casting block no to timeout
+            // provide some differential function so not to couple to `frame`
             //     * T::BlockNumber::from(T::ExpectedBlockTimeMs::get())).into(),
             actual_execution_cost: 0,
             actual_delivery_cost: 0,
@@ -94,31 +109,40 @@ impl XBICheckOut {
     }
 }
 
+/// An XBI message with additional timeout information
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
 pub struct XBICheckIn<BlockNumber> {
+    /// The XBI message
     pub xbi: XBIFormat,
+    /// Timeout information for checking the queue
     pub notification_delivery_timeout: BlockNumber,
+    /// Timeout information for checking the result of the execution
     pub notification_execution_timeout: BlockNumber,
 }
 
+/// An XBI message
 #[derive(Clone, Eq, PartialEq, Debug, Default, Encode, Decode, TypeInfo)]
 pub struct XBIFormat {
+    /// The instruction to execute on the target
     pub instr: XBIInstr,
+    /// Additional information about the target, costs and any user defined timeouts relating to the message
     pub metadata: XBIMetadata,
 }
 
+// TODO: implement into<usize> to specify custom, versioned byte representations. E.g Result = 255
+/// The instruction to execute on the target
 #[derive(Clone, Eq, PartialEq, Debug, TypeInfo)]
 pub enum XBIInstr {
-    // 0
+    /// An opaque message providing the instruction identifier and some bytes
     Unknown {
         identifier: u8,
         params: Vec<u8>,
     },
-    // 1
+    /// A call native to the parachain, this is also opaque and can be custom
     CallNative {
         payload: Data,
     },
-    // 2
+    /// A call to an EVM contract
     CallEvm {
         source: AccountId20, // Could use either [u8; 20] or Junction::AccountKey20
         target: AccountId20, // Could use either [u8; 20] or Junction::AccountKey20
@@ -130,7 +154,7 @@ pub enum XBIInstr {
         nonce: Option<ValueEvm>,
         access_list: Vec<(AccountId20, Vec<sp_core::H256>)>, // Could use Vec<([u8; 20], Vec<[u8; 32]>)>,
     },
-    // 3
+    /// A call to a WASM contract
     CallWasm {
         dest: AccountId32,
         value: Value,
@@ -138,7 +162,7 @@ pub enum XBIInstr {
         storage_deposit_limit: Option<Value>,
         data: Data,
     },
-    // 4
+    /// A call to any other VM
     CallCustom {
         caller: AccountId32,
         dest: AccountId32,
@@ -147,18 +171,18 @@ pub enum XBIInstr {
         limit: Gas,
         additional_params: Data,
     },
-    // 5
+    /// A simple transfer
     Transfer {
         dest: AccountId32,
         value: Value,
     },
-    // 6
+    /// A multiple asset transfer
     TransferAssets {
         currency_id: AssetId,
         dest: AccountId32,
         value: Value,
     },
-    // 7
+    /// A DeFi swap
     Swap {
         asset_out: AssetId,
         asset_in: AssetId,
@@ -166,26 +190,27 @@ pub enum XBIInstr {
         max_limit: Value,
         discount: bool,
     },
-    // 8
+    /// A DeFi Add liquidity instruction
     AddLiquidity {
         asset_a: AssetId,
         asset_b: AssetId,
         amount_a: Value,
         amount_b_max_limit: Value,
     },
-    // 9
+    /// A DeFi Remove liquidity instruction
     RemoveLiquidity {
         asset_a: AssetId,
         asset_b: AssetId,
         liquidity_amount: Value,
     },
-    // 10
+    /// Get the price of a given asset A over asset B
     GetPrice {
         asset_a: AssetId,
         asset_b: AssetId,
         amount: Value,
     },
-    // 255 TODO: make this a tuple type with a struct XbiResult
+    /// Provide the result of an XBI instruction
+    // TODO: make this a tuple type with a struct XbiResult since this would be easier to send back
     Result {
         outcome: XBICheckOutStatus,
         output: Data,
@@ -199,14 +224,19 @@ impl Default for XBIInstr {
     }
 }
 
-pub type Timeout = u32;
-
+/// A type of notification emitted from XBI
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 pub enum XBINotificationKind {
     Sent,
     Delivered,
     Executed,
 }
+
+pub type Timeout = u32;
+
+/// A user specified timeout for the message, denoting when the action should happen, and any tolerance
+/// to when the message should be notified
+// TODO: be specific on the unit of time, allow it to be specified
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, TypeInfo)]
 pub struct ActionNotificationTimeouts {
     pub action: Timeout,
@@ -222,25 +252,41 @@ impl Default for ActionNotificationTimeouts {
     }
 }
 
+/// Additional information about the target, costs and any user defined timeouts relating to the message
 #[derive(Clone, Eq, PartialEq, Debug, Default, Encode, Decode, TypeInfo)]
 pub struct XBIMetadata {
+    /// The XBI identifier
     pub id: sp_core::H256,
+    /// The destination parachain
     pub dest_para_id: u32,
+    /// The src parachain
     pub src_para_id: u32,
+    // TODO: make this nested in a field: timeouts
+    /// Timeouts in relation to when the message should be sent
     pub sent: ActionNotificationTimeouts,
+    /// Timeouts in relation to when the message should be delivered
     pub delivered: ActionNotificationTimeouts,
+    /// Timeouts in relation to when the message should be executed
     pub executed: ActionNotificationTimeouts,
+    // TODO: move this to field: costs
+    /// The maximum cost of the execution of the message
     pub max_exec_cost: Value,
+    /// The maximum cost of sending any notifications
     pub max_notifications_cost: Value,
+    /// The cost of execution and notification
     pub actual_aggregated_cost: Option<Value>,
+    /// The optional known caller
     pub maybe_known_origin: Option<AccountId32>,
+    /// The optional known caller
     pub maybe_fee_asset_id: Option<AssetId>,
 }
 
 /// max_exec_cost satisfies all of the execution fee requirements while going through XCM execution:
 /// max_exec_cost -> exec_in_credit
 /// max_exec_cost -> exec_in_credit -> max execution cost (EVM/WASM::max_gas_fees)
+// TODO: implement builders for XBI metadata fields
 impl XBIMetadata {
+    // TODO: feature flag for this, uncouple, just pass traits
     // pub fn to_exec_in_credit<T: crate::Config, Balance: Encode + Decode + Clone>(
     //     &self,
     // ) -> Result<Balance, crate::Error<T>> {
@@ -248,6 +294,7 @@ impl XBIMetadata {
     //         .map_err(|_e| crate::Error::<T>::EnterFailedOnMultiLocationTransform)
     // }
 
+    /// Provide a hash of the XBI msg id
     pub fn id<Hashing: Hash + Hasher<Out = <Hashing as Hash>::Output>>(
         &self,
     ) -> <Hashing as Hasher>::Out {

--- a/xbi-format/src/xbi_codec.rs
+++ b/xbi-format/src/xbi_codec.rs
@@ -485,9 +485,9 @@ impl Encode for XBIInstr {
 mod tests {
     use super::*;
 
-    use codec::{Decode, Encode};
     use crate::{ActionNotificationTimeouts, XBIFormat, XBIMetadata};
     use crate::{XBICheckOutStatus, XBIInstr};
+    use codec::{Decode, Encode};
 
     #[test]
     fn custom_encodes_decodes_xbi_evm() {
@@ -575,8 +575,8 @@ mod tests {
     fn custom_encodes_decodes_xbi_wasm() {
         let xbi_wasm = XBIInstr::CallWasm {
             dest: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             value: 1,
             gas_limit: 2,
@@ -593,8 +593,8 @@ mod tests {
     fn custom_encodes_decodes_empty_xbi_wasm() {
         let xbi_wasm = XBIInstr::CallWasm {
             dest: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             value: 1,
             gas_limit: 2,
@@ -614,12 +614,12 @@ mod tests {
     fn custom_encodes_decodes_xbi_call_custom() {
         let xbi_call_custom = XBIInstr::CallCustom {
             caller: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             dest: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             value: 1,
             input: vec![8, 9],
@@ -637,12 +637,12 @@ mod tests {
     fn custom_encodes_decodes_empty_xbi_call_custom() {
         let xbi_call_custom = XBIInstr::CallCustom {
             caller: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             dest: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             value: 1,
             input: vec![],
@@ -661,13 +661,14 @@ mod tests {
     fn custom_encodes_decodes_xbi_transfer() {
         let xbi_transfer = XBIInstr::Transfer {
             dest: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             value: 1,
         };
 
-        let decoded_xbi_transfer: XBIInstr = Decode::decode(&mut &xbi_transfer.encode()[..]).unwrap();
+        let decoded_xbi_transfer: XBIInstr =
+            Decode::decode(&mut &xbi_transfer.encode()[..]).unwrap();
         assert_eq!(decoded_xbi_transfer.encode(), xbi_transfer.encode());
         assert_eq!(xbi_transfer, decoded_xbi_transfer);
         assert_eq!(xbi_transfer.encode().len(), 49);
@@ -678,8 +679,8 @@ mod tests {
         let xbi_transfer_assets = XBIInstr::TransferAssets {
             currency_id: 1u32,
             dest: AccountId32::new([
-                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-                2, 2, 2,
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
             ]),
             value: 1,
         };

--- a/xbi-format/src/xbi_codec.rs
+++ b/xbi-format/src/xbi_codec.rs
@@ -280,16 +280,16 @@ impl Decode for XBIInstr {
             }
             // GetPrice
             10 => {
-                let _len: Result<usize, codec::Error> = match input.remaining_len()? {
+                let len: Result<usize, codec::Error> = match input.remaining_len()? {
                     Some(remaining_len) => Ok(remaining_len),
                     None => Err("Wrong XBI Order length".into()),
                 };
 
                 // Minimum length of XBI::CallWasm with empty / none values
                 // TODO: make all these unmagic and provide trait for them
-                // if len? < 52_usize {
-                //     return Err("Wrong XBI Order length".into());
-                // }
+                if len? < 52_usize {
+                    return Err("Wrong XBI Order length".into());
+                }
 
                 let mut asset_a: [u8; 4] = Default::default();
                 let mut asset_b: [u8; 4] = Default::default();
@@ -478,5 +478,232 @@ impl Encode for XBIInstr {
                 witness.encode_to(dest_bytes);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use codec::{Decode, Encode};
+    use crate::{ActionNotificationTimeouts, XBIFormat, XBIMetadata};
+    use crate::{XBICheckOutStatus, XBIInstr};
+
+    #[test]
+    fn custom_encodes_decodes_xbi_evm() {
+        let xbi_evm = XBIInstr::CallEvm {
+            source: AccountId20::repeat_byte(3),
+            target: AccountId20::repeat_byte(2),
+            value: sp_core::U256([1, 0, 0, 0]),
+            input: vec![8, 9],
+            gas_limit: 2,
+            max_fee_per_gas: sp_core::U256([4, 5, 6, 7]),
+            max_priority_fee_per_gas: None,
+            nonce: Some(sp_core::U256([3, 4, 6, 7])),
+            access_list: vec![],
+        };
+
+        let decoded_xbi_evm: XBIInstr = Decode::decode(&mut &xbi_evm.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_evm.encode(), xbi_evm.encode());
+        assert_eq!(xbi_evm, decoded_xbi_evm);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_xbi_evm_and_metadata() {
+        let xbi_evm_format = XBIFormat {
+            instr: XBIInstr::CallEvm {
+                source: AccountId20::repeat_byte(3),
+                target: AccountId20::repeat_byte(2),
+                value: sp_core::U256([1, 0, 0, 0]),
+                input: vec![8, 9],
+                gas_limit: 2,
+                max_fee_per_gas: sp_core::U256([4, 5, 6, 7]),
+                max_priority_fee_per_gas: None,
+                nonce: Some(sp_core::U256([3, 4, 6, 7])),
+                access_list: vec![],
+            },
+            metadata: XBIMetadata {
+                id: sp_core::H256::repeat_byte(2),
+                dest_para_id: 3u32,
+                src_para_id: 4u32,
+                sent: ActionNotificationTimeouts {
+                    action: 1u32,
+                    notification: 2u32,
+                },
+                delivered: ActionNotificationTimeouts {
+                    action: 3u32,
+                    notification: 4u32,
+                },
+                executed: ActionNotificationTimeouts {
+                    action: 4u32,
+                    notification: 5u32,
+                },
+                max_exec_cost: 6u128,
+                max_notifications_cost: 8u128,
+                maybe_known_origin: None,
+                actual_aggregated_cost: None,
+                maybe_fee_asset_id: None,
+            },
+        };
+
+        let decoded_xbi_evm: XBIFormat = Decode::decode(&mut &xbi_evm_format.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_evm.encode(), xbi_evm_format.encode());
+        assert_eq!(xbi_evm_format, decoded_xbi_evm);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_empty_xbi_evm() {
+        let xbi_evm = XBIInstr::CallEvm {
+            source: AccountId20::repeat_byte(3),
+            target: AccountId20::repeat_byte(2),
+            value: sp_core::U256([1, 0, 0, 0]),
+            input: vec![],
+            gas_limit: 2,
+            max_fee_per_gas: sp_core::U256([4, 5, 6, 7]),
+            max_priority_fee_per_gas: None,
+            nonce: None,
+            access_list: vec![],
+        };
+
+        let decoded_xbi_evm: XBIInstr = Decode::decode(&mut &xbi_evm.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_evm.encode(), xbi_evm.encode());
+        assert_eq!(xbi_evm, decoded_xbi_evm);
+        assert_eq!(xbi_evm.encode().len(), 121);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_xbi_wasm() {
+        let xbi_wasm = XBIInstr::CallWasm {
+            dest: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            value: 1,
+            gas_limit: 2,
+            storage_deposit_limit: Some(6),
+            data: vec![8, 9],
+        };
+
+        let decoded_xbi_wasm: XBIInstr = Decode::decode(&mut &xbi_wasm.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_wasm.encode(), xbi_wasm.encode());
+        assert_eq!(xbi_wasm, decoded_xbi_wasm);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_empty_xbi_wasm() {
+        let xbi_wasm = XBIInstr::CallWasm {
+            dest: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            value: 1,
+            gas_limit: 2,
+            storage_deposit_limit: None,
+            data: vec![],
+        };
+
+        let decoded_xbi_wasm: XBIInstr = Decode::decode(&mut &xbi_wasm.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_wasm.encode(), xbi_wasm.encode());
+        assert_eq!(xbi_wasm, decoded_xbi_wasm);
+
+        // Minimum length of XBI::CallWasm with empty / none values
+        assert_eq!(xbi_wasm.encode().len(), 61);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_xbi_call_custom() {
+        let xbi_call_custom = XBIInstr::CallCustom {
+            caller: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            dest: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            value: 1,
+            input: vec![8, 9],
+            limit: 1,
+            additional_params: vec![10u8, 11u8],
+        };
+
+        let decoded_xbi_call_custom: XBIInstr =
+            Decode::decode(&mut &xbi_call_custom.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_call_custom.encode(), xbi_call_custom.encode());
+        assert_eq!(xbi_call_custom, decoded_xbi_call_custom);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_empty_xbi_call_custom() {
+        let xbi_call_custom = XBIInstr::CallCustom {
+            caller: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            dest: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            value: 1,
+            input: vec![],
+            limit: 1,
+            additional_params: vec![],
+        };
+
+        let decoded_xbi_call_custom: XBIInstr =
+            Decode::decode(&mut &xbi_call_custom.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_call_custom.encode(), xbi_call_custom.encode());
+        assert_eq!(xbi_call_custom, decoded_xbi_call_custom);
+        assert_eq!(xbi_call_custom.encode().len(), 93);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_xbi_transfer() {
+        let xbi_transfer = XBIInstr::Transfer {
+            dest: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            value: 1,
+        };
+
+        let decoded_xbi_transfer: XBIInstr = Decode::decode(&mut &xbi_transfer.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_transfer.encode(), xbi_transfer.encode());
+        assert_eq!(xbi_transfer, decoded_xbi_transfer);
+        assert_eq!(xbi_transfer.encode().len(), 49);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_xbi_transfer_assets() {
+        let xbi_transfer_assets = XBIInstr::TransferAssets {
+            currency_id: 1u32,
+            dest: AccountId32::new([
+                2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2,
+            ]),
+            value: 1,
+        };
+
+        let decoded_xbi_transfer_assets: XBIInstr =
+            Decode::decode(&mut &xbi_transfer_assets.encode()[..]).unwrap();
+        assert_eq!(
+            decoded_xbi_transfer_assets.encode(),
+            xbi_transfer_assets.encode()
+        );
+        assert_eq!(xbi_transfer_assets, decoded_xbi_transfer_assets);
+        assert_eq!(xbi_transfer_assets.encode().len(), 53);
+    }
+
+    #[test]
+    fn custom_encodes_decodes_xbi_results() {
+        let xbi_result = XBIInstr::Result {
+            outcome: XBICheckOutStatus::SuccessfullyExecuted,
+            output: vec![1, 2, 3],
+            witness: vec![4, 5, 6],
+        };
+
+        let decoded_xbi_result: XBIInstr = Decode::decode(&mut &xbi_result.encode()[..]).unwrap();
+        assert_eq!(decoded_xbi_result.encode(), xbi_result.encode());
+        assert_eq!(xbi_result, decoded_xbi_result);
     }
 }

--- a/xbi-format/src/xbi_codec.rs
+++ b/xbi-format/src/xbi_codec.rs
@@ -286,6 +286,7 @@ impl Decode for XBIInstr {
                 };
 
                 // Minimum length of XBI::CallWasm with empty / none values
+                // TODO: make all these unmagic and provide trait for them
                 // if len? < 52_usize {
                 //     return Err("Wrong XBI Order length".into());
                 // }


### PR DESCRIPTION
Add documentation to XBI Format.

This covers the 1b. delivery of Web3 Foundation Grant to deliver Specification of XBI Format. See more details at https://github.com/w3f/Grants-Program/blob/master/applications/xbi-format-psp-t3rn.md

The source code of `src/xbi_format.rs` and the main README.md file provide inline documentation of XBI Format. 
Tests of `src/xbi_format.rs` could serve as a basic tutorial on how to use it. 

In the next steps we're implementing the client side sending XBI messages.