### PR TITLE
w3f/Grants-Program img src update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ An XCM-based high-level standard and interface (ABI) for smart contracts.
 
 ## W3F grants
 
-<img align="right" width="400" src="https://github.com/w3f/Grants-Program/blob/master/src/badge_black.svg">
-
+<img align="right" width="400" src="https://github.com/w3f/Grants-Program/blob/57ef638f2bb331c24c569bff02f04c2b3e89bfb0/static/img/badge_black.svg">
 At t3rn, we aim for XBI to become the de-facto standord for integrating with smart contracts all cross the ecosystem. 
 To facilitate that, we aim to implement XBI as a set of grants to enable a transparent, usable specification. 
 


### PR DESCRIPTION
Prior to change image was not found due to `master` branch on w3f/Grants-Program has changed.
This PR points correctly to image in README and change `master` branch to a commit hash, so the image won't be stale after updates to w3f/Grants-Program.