### PR TITLE
feat: encapsulate private fields from the user request

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,37 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          tag: ${{ github.ref_name }}
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: false
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changes }}
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Commit CHANGELOG.md
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: "docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]"
+          file_pattern: CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,10 @@ jobs:
         run: cargo login ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       # TODO reenable substrate abi in the next PR
+      # TODO reenable publishing once we push all the crates(again)
       - name: Release
         id: release
-        run: cargo release --execute --no-confirm -c release.toml --exclude large --exclude slim --exclude xbi-integration-tests --exclude xbi-client ${{ steps.version.outputs.version }}
+        run: cargo release --execute --no-publish --no-confirm -c release.toml --exclude large --exclude slim --exclude xbi-integration-tests --exclude xbi-client ${{ steps.version.outputs.version }}
 
       - name: Send telegram message on primitives release failure
         if: failure() && steps.release.outcome == 'failure'

--- a/crates/channel/src/receiver/frame/mod.rs
+++ b/crates/channel/src/receiver/frame/mod.rs
@@ -75,11 +75,15 @@ mod tests {
 
     #[test]
     fn inverting_destination_works_correctly_when_within_gas() {
-        let mut metadata = XbiMetadata {
-            src_para_id: 1,
-            dest_para_id: 2,
-            ..Default::default()
-        };
+        let mut metadata = XbiMetadata::new(
+            1,
+            2,
+            Default::default(),
+            Fees::new(None, Some(1), Some(10_000_000_000)),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
         assert_eq!(metadata.src_para_id, 1);
         assert_eq!(metadata.dest_para_id, 2);
         invert_destination_from_message(&mut metadata);
@@ -95,16 +99,21 @@ mod tests {
         };
 
         let mut msg = XbiFormat {
-            metadata: XbiMetadata {
-                fees: Fees::new(None, Some(1), Some(10_000_000_000)),
-                ..Default::default()
-            },
+            metadata: XbiMetadata::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Fees::new(None, Some(1), Some(10_000_000_000)),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            ),
             ..Default::default()
         };
 
         let result = handler_to_xbi_result::<()>(&info, &mut msg);
 
-        assert_eq!(msg.metadata.fees.aggregated_cost, 100);
+        assert_eq!(msg.metadata.fees.get_aggregated_cost(), 100);
         assert_eq!(result.status, Status::ExecutionLimitExceeded);
     }
 
@@ -116,16 +125,21 @@ mod tests {
         };
 
         let mut msg = XbiFormat {
-            metadata: XbiMetadata {
-                fees: Fees::new(None, Some(10_000_000_000), Some(10_000_000_000)),
-                ..Default::default()
-            },
+            metadata: XbiMetadata::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Fees::new(None, Some(10_000_000_000), Some(10_000_000_000)),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            ),
             ..Default::default()
         };
 
         let result = handler_to_xbi_result::<()>(&info, &mut msg);
 
-        assert_eq!(msg.metadata.fees.aggregated_cost, 100);
+        assert_eq!(msg.metadata.fees.get_aggregated_cost(), 100);
         assert_eq!(result.status, Status::Success);
     }
 

--- a/crates/channel/src/receiver/frame/mod.rs
+++ b/crates/channel/src/receiver/frame/mod.rs
@@ -18,7 +18,6 @@ pub(crate) fn invert_destination_from_message(metadata: &mut XbiMetadata) {
 }
 
 pub(crate) fn handle_instruction_result<E: ChannelProgressionEmitter>(
-    xbi_id: &Vec<u8>,
     instruction_handle: &Result<
         HandlerInfo<frame_support::weights::Weight>,
         sp_runtime::DispatchErrorWithPostInfo<frame_support::weights::PostDispatchInfo>,
@@ -26,14 +25,13 @@ pub(crate) fn handle_instruction_result<E: ChannelProgressionEmitter>(
     msg: &mut XbiFormat,
 ) -> XbiResult {
     match instruction_handle {
-        Ok(info) => handler_to_xbi_result::<E>(&xbi_id.encode(), info, msg),
-        Err(e) => instruction_error_to_xbi_result(&xbi_id.encode(), e),
+        Ok(info) => handler_to_xbi_result::<E>(info, msg),
+        Err(e) => instruction_error_to_xbi_result(e),
     }
 }
 
 /// Map a result from an xbi handler to a result
 pub(crate) fn handler_to_xbi_result<Emitter: ChannelProgressionEmitter>(
-    xbi_id: &Vec<u8>,
     info: &HandlerInfo<frame_support::weights::Weight>,
     msg: &mut XbiFormat,
 ) -> XbiResult {
@@ -43,10 +41,9 @@ pub(crate) fn handler_to_xbi_result<Emitter: ChannelProgressionEmitter>(
 
     let status: Status = Status::from(&msg.metadata.fees);
 
-    log::debug!(target: "frame-receiver", "XBI handler status: {:?} for id {:?}", status, xbi_id);
+    log::debug!(target: "frame-receiver", "XBI handler status: {:?} for id {:?}", status, msg.metadata.get_id());
 
     XbiResult {
-        id: xbi_id.encode(),
         status,
         output: info.output.clone(),
         ..Default::default()
@@ -55,12 +52,10 @@ pub(crate) fn handler_to_xbi_result<Emitter: ChannelProgressionEmitter>(
 
 // TODO[Style]: Move to From implementation
 pub(crate) fn instruction_error_to_xbi_result(
-    xbi_id: &Vec<u8>,
     err: &sp_runtime::DispatchErrorWithPostInfo<frame_support::weights::PostDispatchInfo>,
 ) -> XbiResult {
     log::error!(target: "frame-receiver", "Failed to execute instruction: {:?}", err);
     XbiResult {
-        id: xbi_id.encode(),
         status: Status::FailedExecution,
         output: err.encode(),
         ..Default::default()
@@ -94,8 +89,6 @@ mod tests {
 
     #[test]
     fn xbi_handler_maps_to_result_correctly_when_exceeded_gas() {
-        let id = b"hello".to_vec();
-
         let info = HandlerInfo {
             weight: 100,
             output: b"world".to_vec(),
@@ -109,17 +102,14 @@ mod tests {
             ..Default::default()
         };
 
-        let result = handler_to_xbi_result::<()>(&id, &info, &mut msg);
+        let result = handler_to_xbi_result::<()>(&info, &mut msg);
 
         assert_eq!(msg.metadata.fees.aggregated_cost, 100);
-        assert_eq!(result.id, id.encode());
         assert_eq!(result.status, Status::ExecutionLimitExceeded);
     }
 
     #[test]
     fn xbi_handler_maps_to_result_correctly() {
-        let id = b"hello".to_vec();
-
         let info = HandlerInfo {
             weight: 100,
             output: b"world".to_vec(),
@@ -133,17 +123,14 @@ mod tests {
             ..Default::default()
         };
 
-        let result = handler_to_xbi_result::<()>(&id, &info, &mut msg);
+        let result = handler_to_xbi_result::<()>(&info, &mut msg);
 
         assert_eq!(msg.metadata.fees.aggregated_cost, 100);
-        assert_eq!(result.id, id.encode());
         assert_eq!(result.status, Status::Success);
     }
 
     #[test]
     fn xbi_handler_error_maps_to_result_correctly() {
-        let id = b"hello".to_vec();
-
         let err = DispatchErrorWithPostInfo {
             post_info: PostDispatchInfo {
                 actual_weight: Some(1000),
@@ -151,9 +138,8 @@ mod tests {
             },
             error: sp_runtime::DispatchError::Other("Fail"),
         };
-        let result = instruction_error_to_xbi_result(&id, &err);
+        let result = instruction_error_to_xbi_result(&err);
 
-        assert_eq!(result.id, id.encode());
         assert_eq!(result.status, Status::FailedExecution);
         assert_eq!(result.output, err.encode());
     }

--- a/crates/channel/src/receiver/frame/queue_backed.rs
+++ b/crates/channel/src/receiver/frame/queue_backed.rs
@@ -37,7 +37,7 @@ where
         let current_block: u32 = <frame_system::Pallet<T>>::block_number().unique_saturated_into();
 
         // progress to delivered
-        msg.metadata.timesheet.progress(Delivered(current_block));
+        msg.metadata.progress(Delivered(current_block));
 
         Emitter::emit_received(Either::Left(msg));
 
@@ -48,7 +48,7 @@ where
         let xbi_result = handle_instruction_result::<Emitter>(&instruction_result, msg);
 
         // progress to executed
-        msg.metadata.timesheet.progress(Executed(current_block));
+        msg.metadata.progress(Executed(current_block));
 
         Emitter::emit_request_handled(
             &xbi_result,

--- a/crates/channel/src/receiver/frame/queue_backed.rs
+++ b/crates/channel/src/receiver/frame/queue_backed.rs
@@ -1,6 +1,5 @@
 use crate::receiver::frame::invert_destination_from_message;
 use crate::receiver::Receiver as ReceiverExt;
-use codec::Encode;
 use frame_support::pallet_prelude::DispatchResultWithPostInfo;
 use frame_system::{ensure_signed, Config};
 use sp_runtime::{traits::UniqueSaturatedInto, Either};
@@ -44,12 +43,9 @@ where
 
         invert_destination_from_message(&mut msg.metadata);
 
-        let xbi_id = msg.metadata.id::<T::Hashing>();
-
         let instruction_result = InstructionHandler::handle(origin, msg);
 
-        let xbi_result =
-            handle_instruction_result::<Emitter>(&xbi_id.encode(), &instruction_result, msg);
+        let xbi_result = handle_instruction_result::<Emitter>(&instruction_result, msg);
 
         // progress to executed
         msg.metadata.timesheet.progress(Executed(current_block));

--- a/crates/channel/src/receiver/frame/sync.rs
+++ b/crates/channel/src/receiver/frame/sync.rs
@@ -1,5 +1,4 @@
 use crate::{receiver::frame::invert_destination_from_message, receiver::Receiver as ReceiverExt};
-use codec::Encode;
 use frame_support::pallet_prelude::DispatchResultWithPostInfo;
 use frame_system::{ensure_signed, Config};
 use sp_runtime::{traits::UniqueSaturatedInto, Either};
@@ -45,12 +44,9 @@ where
 
         invert_destination_from_message(&mut msg.metadata);
 
-        let xbi_id = msg.metadata.id::<T::Hashing>();
-
         let instruction_handle = InstructionHandler::handle(origin, msg);
 
-        let xbi_result =
-            handle_instruction_result::<Emitter>(&xbi_id.encode(), &instruction_handle, msg);
+        let xbi_result = handle_instruction_result::<Emitter>(&instruction_handle, msg);
 
         msg.metadata.timesheet.progress(Executed(current_block));
 

--- a/crates/channel/src/receiver/frame/sync.rs
+++ b/crates/channel/src/receiver/frame/sync.rs
@@ -38,7 +38,7 @@ where
         let _who = ensure_signed(origin.clone())?;
         let current_block: u32 = <frame_system::Pallet<T>>::block_number().unique_saturated_into();
 
-        msg.metadata.timesheet.progress(Delivered(current_block));
+        msg.metadata.progress(Delivered(current_block));
 
         Emitter::emit_received(Either::Left(msg));
 
@@ -48,7 +48,7 @@ where
 
         let xbi_result = handle_instruction_result::<Emitter>(&instruction_handle, msg);
 
-        msg.metadata.timesheet.progress(Executed(current_block));
+        msg.metadata.progress(Executed(current_block));
 
         Emitter::emit_request_handled(
             &xbi_result,

--- a/crates/channel/src/sender/frame/queue_backed.rs
+++ b/crates/channel/src/sender/frame/queue_backed.rs
@@ -52,8 +52,8 @@ where
         match &mut msg {
             Message::Request(format) => {
                 // Progress the timestamps in one go TODO: this will change when we finish up queue impl
-                format.metadata.timesheet.progress(Submitted(current_block));
-                format.metadata.timesheet.progress(Sent(current_block));
+                format.metadata.progress(Submitted(current_block));
+                format.metadata.progress(Sent(current_block));
 
                 // TODO: charge as reserve because we pay as sovereign
                 // TODO: actually reserve fees
@@ -97,7 +97,7 @@ where
             }
             Message::Response(result, metadata) => {
                 // Progress the delivered timestamp
-                metadata.timesheet.progress(Responded(current_block));
+                metadata.progress(Responded(current_block));
 
                 let require_weight_at_most = 1_000_000_000;
 

--- a/crates/channel/src/sender/frame/sync.rs
+++ b/crates/channel/src/sender/frame/sync.rs
@@ -40,8 +40,8 @@ where
         match &mut msg {
             Message::Request(format) => {
                 // Progress the timestamps in one go
-                format.metadata.timesheet.progress(Submitted(current_block));
-                format.metadata.timesheet.progress(Sent(current_block));
+                format.metadata.progress(Submitted(current_block));
+                format.metadata.progress(Sent(current_block));
 
                 // TODO: charge as reserve because we pay as sovereign
                 // TODO: actually reserve fees
@@ -78,7 +78,7 @@ where
             }
             Message::Response(result, metadata) => {
                 // Progress the delivered timestamp
-                metadata.timesheet.progress(Responded(current_block));
+                metadata.progress(Responded(current_block));
 
                 // TODO: Set this and get it from config
                 let require_weight_at_most = 1_000_000_000;

--- a/crates/format/src/lib.rs
+++ b/crates/format/src/lib.rs
@@ -4,7 +4,7 @@ use codec::{Decode, Encode, FullCodec};
 use core::fmt::Debug;
 use scale_info::TypeInfo;
 use sp_core::Hasher;
-use sp_runtime::traits::Hash;
+use sp_runtime::traits::{BlakeTwo256, Hash};
 use sp_runtime::AccountId32;
 use sp_std::prelude::*;
 use sp_std::vec;
@@ -66,61 +66,6 @@ pub struct XbiCheckOut {
     // TODO: this can be calculated by a function on XbiCheckout
     /// The cost of the message with the execution cost
     pub actual_aggregated_cost: Value,
-}
-
-impl XbiCheckOut {
-    pub fn new<T: frame_system::Config>(
-        id: T::Hash,
-        _delivery_timeout: T::BlockNumber,
-        output: Vec<u8>,
-        resolution_status: Status,
-        actual_execution_cost: Value,
-        actual_delivery_cost: Value,
-        actual_aggregated_cost: Value,
-    ) -> Self {
-        XbiCheckOut {
-            xbi: XbiInstruction::Result(XbiResult {
-                id: id.encode(),
-                status: resolution_status.clone(),
-                output,
-                witness: vec![],
-            }),
-            resolution_status,
-            checkout_timeout: Default::default(),
-            // fixme: make below work - casting block no to timeout
-            // provide some differential function so not to couple to `frame`
-            // checkout_timeout: ((frame_system::Pallet::<T>::block_number() - delivery_timeout)
-            //     * T::BlockNumber::from(T::ExpectedBlockTimeMs::get())).into(),
-            actual_execution_cost,
-            actual_delivery_cost,
-            actual_aggregated_cost,
-        }
-    }
-
-    /// Instantiate a new checkout with default costs
-    pub fn new_ignore_costs<T: frame_system::Config>(
-        id: T::Hash,
-        _delivery_timeout: T::BlockNumber,
-        output: Vec<u8>,
-        resolution_status: Status,
-    ) -> Self {
-        XbiCheckOut {
-            xbi: XbiInstruction::Result(XbiResult {
-                id: id.encode(),
-                status: resolution_status.clone(),
-                output,
-                witness: vec![],
-            }),
-            resolution_status,
-            checkout_timeout: Default::default(),
-            // fixme: make below work - casting block no to timeout
-            // provide some differential function so not to couple to `frame`
-            //     * T::BlockNumber::from(T::ExpectedBlockTimeMs::get())).into(),
-            actual_execution_cost: 0,
-            actual_delivery_cost: 0,
-            actual_aggregated_cost: 0,
-        }
-    }
 }
 
 /// An XBI message with additional timeout information
@@ -300,7 +245,7 @@ pub struct Fees {
     /// The maximum cost of sending any notifications
     pub notification_cost_limit: Value,
     /// The cost of execution and notification
-    pub aggregated_cost: Value,
+    aggregated_cost: Value,
 }
 
 impl Fees {
@@ -339,6 +284,10 @@ impl Fees {
 
     pub fn notification_limit_exceeded(&self) -> bool {
         self.aggregated_cost > self.notification_cost_limit
+    }
+
+    pub fn get_aggregated_cost(&self) -> Value {
+        self.aggregated_cost
     }
 }
 
@@ -379,7 +328,6 @@ impl<BlockNumber: FullCodec + TypeInfo> XbiTimeSheet<BlockNumber> {
         }
     }
 
-    // TODO: The current progress field should just be an enum, and we can progress by either providing the enum or the next step.
     pub fn progress(&mut self, timestamp: Timestamp<BlockNumber>) -> &mut Self {
         match timestamp {
             Timestamp::Submitted(block) => self.submitted = Some(block),
@@ -396,7 +344,7 @@ impl<BlockNumber: FullCodec + TypeInfo> XbiTimeSheet<BlockNumber> {
 #[derive(Clone, Eq, PartialEq, Debug, Default, Encode, Decode, TypeInfo)]
 pub struct XbiMetadata {
     /// The XBI identifier
-    pub id: sp_core::H256,
+    id: sp_core::H256,
     /// The destination parachain
     pub dest_para_id: u32,
     /// The src parachain
@@ -425,30 +373,71 @@ impl XbiMetadata {
     // }
 
     /// Provide a hash of the XBI msg id
-    pub fn id<Hashing: Hash + Hasher<Out = <Hashing as Hash>::Output>>(
+    pub fn rehash_id<Hashing: Hash + Hasher<Out = <Hashing as Hash>::Output>>(
         &self,
     ) -> <Hashing as Hasher>::Out {
         <Hashing as Hasher>::hash(&self.id.encode()[..])
     }
 
+    /// Provide the hashable fields for the metadata to retrieve the id, this omits the things that are normally different across the lifecycle of the message
+    pub(crate) fn sane_fields(&self) -> Vec<Vec<u8>> {
+        vec![
+            self.src_para_id.encode(),
+            self.dest_para_id.encode(),
+            self.timeouts.encode(),
+            self.fees.asset.encode(),
+            self.fees.execution_cost_limit.encode(),
+            self.fees.notification_cost_limit.encode(),
+            self.maybe_known_origin.encode(),
+        ]
+    }
+
+    pub fn sane_hashable_fields(&self) -> Vec<u8> {
+        self.sane_fields().concat()
+    }
+
+    pub fn enrich_id<Hashing: Hasher<Out = sp_core::H256>>(
+        &mut self,
+        nonce: u32,
+        seed: Option<&[u8]>,
+    ) -> &mut Self {
+        if self.id == sp_core::H256::default() {
+            let mut hash_contents = vec![nonce.encode(), self.sane_hashable_fields()];
+            if let Some(seed) = seed {
+                hash_contents.push(seed.to_vec());
+            }
+
+            self.id = Hashing::hash(&hash_contents.concat()[..]);
+        } else {
+            log::warn!("Can only enrich the id if it has not been enriched already");
+        }
+        self
+    }
+
+    pub fn get_id(&self) -> sp_core::H256 {
+        self.id
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        id: sp_core::H256,
-        dest_para_id: u32,
         src_para_id: u32,
+        dest_para_id: u32,
         timeouts: Timeouts,
         fees: Fees,
         maybe_known_origin: Option<AccountId32>,
+        nonce: u32,
+        seed: Option<&[u8]>,
     ) -> Self {
-        XbiMetadata {
-            id,
+        let mut base = XbiMetadata {
+            id: Default::default(),
             dest_para_id,
             src_para_id,
             timeouts,
             timesheet: Default::default(),
             fees,
             maybe_known_origin,
-        }
+        };
+        base.enrich_id::<BlakeTwo256>(nonce, seed).to_owned()
     }
 
     pub fn progress(&mut self, timestamp: Timestamp<u32>) -> &mut Self {
@@ -466,7 +455,7 @@ mod tests {
     #[test]
     fn can_hash_id() {
         let meta = XbiMetadata::default();
-        let hash = meta.id::<BlakeTwo256>();
+        let hash = meta.rehash_id::<BlakeTwo256>();
         assert_eq!(hash, <BlakeTwo256 as Hasher>::hash(&meta.id.0))
     }
 
@@ -527,5 +516,28 @@ mod tests {
 
         fees.notification_cost_limit = 0;
         assert_eq!(Status::from(&fees), Status::NotificationLimitExceeded);
+    }
+
+    #[test]
+    fn test_can_enrich_id() {
+        let mut meta = XbiMetadata::default();
+        let nonce = 1;
+
+        meta.enrich_id::<sp_runtime::traits::BlakeTwo256>(nonce, None);
+        assert_ne!(meta.id, sp_core::H256::default());
+        let expected_fields = vec![nonce.encode(), meta.sane_hashable_fields()].concat();
+        assert_eq!(
+            meta.id,
+            <sp_runtime::traits::BlakeTwo256 as sp_core::Hasher>::hash(&expected_fields[..])
+        );
+    }
+
+    // test that the sane_hashable fields do not contain the insane fields
+    #[test]
+    fn test_sane_hashable_fields() {
+        let meta = XbiMetadata::default();
+        let sane_fields = meta.sane_fields();
+        assert!(!sane_fields.contains(&meta.id.encode()));
+        assert!(!sane_fields.contains(&meta.timesheet.encode()));
     }
 }

--- a/crates/format/src/lib.rs
+++ b/crates/format/src/lib.rs
@@ -404,7 +404,7 @@ pub struct XbiMetadata {
     /// User provided timeouts
     pub timeouts: Timeouts,
     /// The time sheet providing timestamps to each of the xbi progression
-    pub timesheet: XbiTimeSheet<u32>, // TODO: assume u32 is block number
+    timesheet: XbiTimeSheet<u32>, // TODO: assume u32 is block number
     /// User provided cost limits
     pub fees: Fees,
     /// The optional known caller
@@ -451,22 +451,9 @@ impl XbiMetadata {
         }
     }
 
-    pub fn new_with_default_timeouts(
-        id: sp_core::H256,
-        dest_para_id: u32,
-        src_para_id: u32,
-        costs: Fees,
-        maybe_known_origin: Option<AccountId32>,
-    ) -> Self {
-        XbiMetadata {
-            id,
-            dest_para_id,
-            src_para_id,
-            timeouts: Timeouts::default(),
-            timesheet: Default::default(),
-            fees: costs,
-            maybe_known_origin,
-        }
+    pub fn progress(&mut self, timestamp: Timestamp<u32>) -> &mut Self {
+        self.timesheet.progress(timestamp);
+        self
     }
 }
 

--- a/crates/format/src/lib.rs
+++ b/crates/format/src/lib.rs
@@ -215,9 +215,6 @@ pub enum XbiInstruction {
         asset_b: AssetId,
         amount: Value,
     },
-    /// Provide the result of an XBI instruction
-    // TODO: make this a tuple type with a struct XbiResult since this would be easier to send back
-    Result(XbiResult),
 }
 
 impl Default for XbiInstruction {
@@ -229,7 +226,6 @@ impl Default for XbiInstruction {
 /// A result containing the status of the call
 #[derive(Debug, Clone, Eq, Default, PartialEq, Encode, Decode, TypeInfo)]
 pub struct XbiResult {
-    pub id: Data, // TODO: maybe make hash
     pub status: Status,
     pub output: Data,
     pub witness: Data,

--- a/integration-test/src/large.rs
+++ b/integration-test/src/large.rs
@@ -506,7 +506,7 @@ mod tests {
         Large::execute_with(|| {
             assert_ok!(XbiPortal::send(
                 large::Origin::signed(ALICE),
-                Message::Request(XbiFormat {
+                XbiFormat {
                     instr: XbiInstruction::CallEvm {
                         source: SubstrateAbiConverter::try_convert(ALICE).unwrap(),
                         target: substrate_abi::AccountId20::from_low_u64_be(1),
@@ -519,14 +519,15 @@ mod tests {
                         access_list: vec![]
                     },
                     metadata: XbiMetadata::new(
-                        Default::default(),
-                        SLIM_PARA_ID,
                         LARGE_PARA_ID,
+                        SLIM_PARA_ID,
                         Default::default(),
                         Fees::new(Some(1), Some(90_000_000_000), Some(10_000_000_000)),
                         None,
+                        Default::default(),
+                        Default::default(),
                     ),
-                })
+                }
             ));
 
             assert_xcmp_sent!(large);
@@ -567,7 +568,7 @@ mod tests {
         Slim::execute_with(|| {
             assert_ok!(slim::XbiPortal::send(
                 slim::Origin::signed(ALICE),
-                Message::Request(XbiFormat {
+                XbiFormat {
                     instr: XbiInstruction::CallEvm {
                         source: SubstrateAbiConverter::try_convert(ALICE).unwrap(),
                         target: substrate_abi::AccountId20::from_low_u64_be(1),
@@ -580,14 +581,15 @@ mod tests {
                         access_list: vec![]
                     },
                     metadata: XbiMetadata::new(
-                        Default::default(),
-                        LARGE_PARA_ID,
                         SLIM_PARA_ID,
+                        LARGE_PARA_ID,
                         Default::default(),
                         Fees::new(Some(1), Some(90_000_000_000), Some(10_000_000_000)),
                         None,
+                        Default::default(),
+                        Default::default(),
                     ),
-                })
+                }
             ));
 
             crate::slim::log_all_events("Slim");
@@ -640,7 +642,7 @@ mod tests {
         Slim::execute_with(|| {
             assert_ok!(slim::XbiPortal::send(
                 slim::Origin::signed(ALICE),
-                Message::Request(XbiFormat {
+                XbiFormat {
                     instr: XbiInstruction::CallWasm {
                         dest: hex_literal::hex!(
                             "18a84a38cff91f3345a66802803f8959d11d4d2315a082bfeb2a49ce72b2577f"
@@ -652,14 +654,15 @@ mod tests {
                         data: b"".to_vec()
                     },
                     metadata: XbiMetadata::new(
-                        Default::default(),
-                        LARGE_PARA_ID,
                         SLIM_PARA_ID,
+                        LARGE_PARA_ID,
                         Default::default(),
                         Fees::new(Some(1), Some(90_000_000_000), Some(10_000_000_000)),
                         None,
+                        Default::default(),
+                        Default::default(),
                     ),
-                })
+                }
             ));
             crate::slim::log_all_events("Slim");
             assert_xcmp_sent!(slim);
@@ -712,7 +715,7 @@ mod tests {
         Slim::execute_with(|| {
             assert_ok!(slim::XbiPortal::send(
                 slim::Origin::signed(ALICE),
-                Message::Request(XbiFormat {
+                XbiFormat {
                     instr: XbiInstruction::CallWasm {
                         dest: hex_literal::hex!(
                             "18a84a38cff91f3345a66802803f8959d11d4d2315a082bfeb2a49ce72b2577f"
@@ -724,14 +727,15 @@ mod tests {
                         data: b"".to_vec()
                     },
                     metadata: XbiMetadata::new(
-                        Default::default(),
-                        LARGE_PARA_ID,
                         SLIM_PARA_ID,
+                        LARGE_PARA_ID,
                         Default::default(),
                         Fees::new(Some(1), Some(100_000), Some(10_000_000_000)),
                         None,
+                        Default::default(),
+                        Default::default(),
                     ),
-                })
+                }
             ));
 
             crate::slim::log_all_events("Slim");

--- a/pallets/portal/src/xbi_scabi.rs
+++ b/pallets/portal/src/xbi_scabi.rs
@@ -1,5 +1,4 @@
 use crate::{pallet, xbi_abi::*, BalanceOf, Error};
-use codec::Encode;
 use frame_support::{dispatch::PostDispatchInfo, weights::Weight};
 use frame_system::pallet_prelude::OriginFor;
 use sp_core::{H160, H256, U256};
@@ -56,14 +55,6 @@ pub trait Scabi<T: pallet::Config> {
         data: Vec<u8>,
         debug: bool,
     ) -> Result<XbiInstruction, Error<T>>;
-
-    fn post_dispatch_info_2_xbi_checkout(
-        id: T::Hash,
-        post_dispatch_info: PostDispatchInfo,
-        notification_delivery_timeout: T::BlockNumber,
-        resolution_status: Status,
-        actual_delivery_cost: Value,
-    ) -> Result<XbiCheckOut, Error<T>>;
 
     fn xbi_checkout_2_post_dispatch_info(
         xbi_checkout: XbiCheckOut,
@@ -162,37 +153,6 @@ impl<T: crate::Config + frame_system::Config> Scabi<T> for XbiAbi<T> {
             nonce: None,
             access_list: vec![],
         })
-    }
-
-    fn post_dispatch_info_2_xbi_checkout(
-        id: T::Hash,
-        post_dispatch_info: PostDispatchInfo,
-        notification_delivery_timeout: T::BlockNumber,
-        resolution_status: Status,
-        actual_delivery_cost: Value,
-    ) -> Result<XbiCheckOut, Error<T>> {
-        let actual_execution_cost =
-            if let Some(some_actual_weight) = post_dispatch_info.actual_weight {
-                some_actual_weight.into()
-            } else {
-                0
-            };
-
-        let actual_aggregated_cost =
-            if let Some(v) = actual_delivery_cost.checked_add(actual_delivery_cost) {
-                v
-            } else {
-                return Err(Error::ArithmeticErrorOverflow);
-            };
-        Ok(XbiCheckOut::new::<T>(
-            id,
-            notification_delivery_timeout,
-            post_dispatch_info.encode(),
-            resolution_status,
-            actual_execution_cost,
-            actual_delivery_cost,
-            actual_aggregated_cost,
-        ))
     }
 
     fn xbi_checkout_2_post_dispatch_info(


### PR DESCRIPTION
This hides the ID, timesheet and aggregate cost from the user when requesting a message.

Also this deprecates the previous way of passing results back, since we specify this higher up in the protocol.

closes https://github.com/t3rn/xbi/issues/17
closes https://github.com/t3rn/xbi/issues/19